### PR TITLE
Add ModuleCode field class

### DIFF
--- a/src/main/java/seedu/address/model/module/ModuleCode.java
+++ b/src/main/java/seedu/address/model/module/ModuleCode.java
@@ -1,0 +1,62 @@
+package seedu.address.model.module;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Module Code in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidModuleCode(String)}
+ */
+public class ModuleCode {
+    public static final String MESSAGE_CONSTRAINTS =
+        "Module code should be in NUS format (e.g., CS2103T)";
+    /*
+     * The module code must:
+     * 1. Start with 2-3 uppercase letters
+     * 2. Followed by exactly 4 digits
+     * 3. Optionally end with 1 uppercase letter
+     */
+    public static final String VALIDATION_REGEX = "[A-Z]{2,3}\\d{4}[A-Z]?";
+    public final String value;
+
+    /**
+     * Constructs a {@code ModuleCode}.
+     *
+     * @param moduleCode A valid module code.
+     */
+    public ModuleCode(String moduleCode) {
+        requireNonNull(moduleCode);
+        checkArgument(isValidModuleCode(moduleCode), MESSAGE_CONSTRAINTS);
+        value = moduleCode;
+    }
+    /**
+     * Returns true if a given string is a valid module code.
+     */
+    public static boolean isValidModuleCode(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ModuleCode)) {
+            return false;
+        }
+
+        ModuleCode otherModuleCode = (ModuleCode) other;
+        return value.equals(otherModuleCode.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/test/java/seedu/address/model/module/ModuleCodeTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleCodeTest.java
@@ -1,0 +1,52 @@
+package seedu.address.model.module;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class ModuleCodeTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new ModuleCode(null));
+    }
+
+    @Test
+    public void constructor_invalidModuleCode_throwsIllegalArgumentException() {
+        String invalidModuleCode = "";
+        assertThrows(IllegalArgumentException.class, () -> new ModuleCode(invalidModuleCode));
+    }
+
+    @Test
+    public void isValidModuleCode() {
+        assertThrows(NullPointerException.class, () -> ModuleCode.isValidModuleCode(null));
+        // Invalid module codes - test the variations!
+        assertFalse(ModuleCode.isValidModuleCode(""));
+        assertFalse(ModuleCode.isValidModuleCode(" "));
+        assertFalse(ModuleCode.isValidModuleCode("C2103T"));
+        assertFalse(ModuleCode.isValidModuleCode("CSCI2103"));
+        assertFalse(ModuleCode.isValidModuleCode("CS210"));
+        assertFalse(ModuleCode.isValidModuleCode("CS21034"));
+        assertFalse(ModuleCode.isValidModuleCode("cs2103t"));
+        assertFalse(ModuleCode.isValidModuleCode("CS 2103T"));
+        // Valid module codes - test the variations!
+        assertTrue(ModuleCode.isValidModuleCode("CS2103"));
+        assertTrue(ModuleCode.isValidModuleCode("CS2103T"));
+        assertTrue(ModuleCode.isValidModuleCode("GEA1000"));
+        assertTrue(ModuleCode.isValidModuleCode("GEA1000H"));
+        assertTrue(ModuleCode.isValidModuleCode("AA0000"));
+        assertTrue(ModuleCode.isValidModuleCode("ZZZ9999Z"));
+    }
+
+    @Test
+    public void equals() {
+        ModuleCode moduleCode = new ModuleCode("CS2103");
+        assertTrue(moduleCode.equals(new ModuleCode("CS2103")));
+        assertTrue(moduleCode.equals(moduleCode));
+        assertFalse(moduleCode.equals(null));
+        assertFalse(moduleCode.equals(new Object()));
+        assertFalse(moduleCode.equals(5.0f));
+        assertFalse(moduleCode.equals(new ModuleCode("CS2103T")));
+    }
+}


### PR DESCRIPTION
This PR adds the ModuleCode field class to represent NUS module codes.

## Implementation Details
- Created \`ModuleCode.java\` in new \`model.module\` package
- Validates format: 2-3 uppercase letters + 4 digits + optional suffix
- Examples: CS2103T, GEA1000, MA1521

## Testing
- Created \`ModuleCodeTest.java\` with comprehensive tests
- All existing tests still pass ✅
- New tests pass ✅

Contributes to: Add Student feature for TeachMate MVP