### PR TITLE
Add CLI prefixes for StudentId and ModuleCode

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-
+    public static final Prefix PREFIX_STUDENT_ID = new Prefix("s/");
+    public static final Prefix PREFIX_MODULE_CODE = new Prefix("m/");
 }


### PR DESCRIPTION
- Add PREFIX_STUDENT_ID constant (s/)
- Add PREFIX_MODULE_CODE constant (m/)
- Prepares parser infrastructure for Add Student command
- These prefixes will be used in AddCommandParser to parse student IDs and module codes

Contributes to: Add Student feature for TeachMate MVP
#46 