### PR TITLE
Change Person to support multiple ModuleCodes

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -42,8 +42,15 @@ public class Messages {
                 .append("; Email: ")
                 .append(person.getEmail())
                 .append("; Address: ")
-                .append(person.getAddress())
-                .append("; Tags: ");
+                .append(person.getAddress());
+        if (person.getStudentId() != null) {
+            builder.append("; Student ID: ").append(person.getStudentId());
+        }
+        if (!person.getModuleCodes().isEmpty()) {
+            builder.append("; Module Codes: ");
+            person.getModuleCodes().forEach(mc -> builder.append(mc).append(" "));
+        }
+        builder.append("; Tags: ");
         person.getTags().forEach(builder::append);
         return builder.toString();
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -106,11 +106,12 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         StudentId updatedStudentId = editPersonDescriptor.getStudentId().orElse(personToEdit.getStudentId());
-        ModuleCode updatedModuleCode = editPersonDescriptor.getModuleCode().orElse(personToEdit.getModuleCode());
+        Set<ModuleCode> updatedModuleCodes = editPersonDescriptor.getModuleCodes()
+                    .orElse(personToEdit.getModuleCodes());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags,
-                updatedStudentId, updatedModuleCode);
+                updatedStudentId, updatedModuleCodes);
     }
 
     @Override
@@ -147,7 +148,7 @@ public class EditCommand extends Command {
         private Email email;
         private Address address;
         private StudentId studentId;
-        private ModuleCode moduleCode;
+        private Set<ModuleCode> moduleCodes;
         private Set<Tag> tags;
 
         public EditPersonDescriptor() {}
@@ -163,14 +164,14 @@ public class EditCommand extends Command {
             setAddress(toCopy.address);
             setTags(toCopy.tags);
             setStudentId(toCopy.studentId);
-            setModuleCode(toCopy.moduleCode);
+            setModuleCodes(toCopy.moduleCodes);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags, studentId, moduleCode);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags, studentId, moduleCodes);
         }
 
         public void setName(Name name) {
@@ -213,12 +214,12 @@ public class EditCommand extends Command {
             return Optional.ofNullable(studentId);
         }
 
-        public void setModuleCode(ModuleCode moduleCode) {
-            this.moduleCode = moduleCode;
+        public void setModuleCodes(Set<ModuleCode> moduleCodes) {
+            this.moduleCodes = (moduleCodes != null) ? new HashSet<>(moduleCodes) : null;
         }
 
-        public Optional<ModuleCode> getModuleCode() {
-            return Optional.ofNullable(moduleCode);
+        public Optional<Set<ModuleCode>> getModuleCodes() {
+            return Optional.ofNullable(moduleCodes);
         }
 
         /**
@@ -255,7 +256,7 @@ public class EditCommand extends Command {
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(address, otherEditPersonDescriptor.address)
                     && Objects.equals(studentId, otherEditPersonDescriptor.studentId)
-                    && Objects.equals(moduleCode, otherEditPersonDescriptor.moduleCode)
+                    && Objects.equals(moduleCodes, otherEditPersonDescriptor.moduleCodes)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 
@@ -267,7 +268,7 @@ public class EditCommand extends Command {
                     .add("email", email)
                     .add("address", address)
                     .add("student Id", studentId)
-                    .add("module code", moduleCode)
+                    .add("module codes", moduleCodes)
                     .add("tags", tags)
                     .toString();
         }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -49,8 +49,8 @@ public class ListCommand extends Command {
 
         ModuleCode target = moduleCode.get();
         // predicate to filter persons by module code
-        Predicate<Person> modulePredicate = person -> person.getModuleCode() != null
-                && person.getModuleCode().equals(moduleCode.get());
+        Predicate<Person> modulePredicate = person -> person.getModuleCodes().stream()
+                .anyMatch(mc -> mc.equals(moduleCode.get()));
 
         model.updateFilteredPersonList(modulePredicate);
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -65,9 +65,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_STUDENT_ID).isPresent()) {
             editPersonDescriptor.setStudentId(ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENT_ID).get()));
         }
-        if (argMultimap.getValue(PREFIX_MODULE_CODE).isPresent()) {
-            editPersonDescriptor.setModuleCode(ParserUtil.parseModuleCode(argMultimap
-                .getValue(PREFIX_MODULE_CODE).get()));
+        if (!argMultimap.getAllValues(PREFIX_MODULE_CODE).isEmpty()) {
+            editPersonDescriptor.setModuleCodes(ParserUtil.parseModuleCodes(
+                    argMultimap.getAllValues(PREFIX_MODULE_CODE)));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -128,6 +128,18 @@ public class ParserUtil {
     }
 
     /**
+     * Parses {@code Collection<String> moduleCodes} into a {@code Set<ModuleCode>}.
+     */
+    public static Set<ModuleCode> parseModuleCodes(Collection<String> moduleCodes) throws ParseException {
+        requireNonNull(moduleCodes);
+        final Set<ModuleCode> moduleCodeSet = new HashSet<>();
+        for (String moduleCodeName : moduleCodes) {
+            moduleCodeSet.add(parseModuleCode(moduleCodeName));
+        }
+        return moduleCodeSet;
+    }
+
+    /**
      * Parses a {@code String tag} into a {@code Tag}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -22,7 +22,7 @@ public class Person {
     private final Phone phone;
     private final Email email;
     private final StudentId studentId;
-    private final ModuleCode moduleCode;
+    private final Set<ModuleCode> moduleCodes = new HashSet<>();
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
@@ -31,7 +31,7 @@ public class Person {
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags,
-        StudentId studentId, ModuleCode moduleCode) {
+                  StudentId studentId, Set<ModuleCode> moduleCodes) {
         requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
@@ -39,7 +39,9 @@ public class Person {
         this.address = address;
         this.tags.addAll(tags);
         this.studentId = studentId;
-        this.moduleCode = moduleCode;
+        if (moduleCodes != null) {
+            this.moduleCodes.addAll(moduleCodes);
+        }
     }
 
     /**
@@ -53,7 +55,6 @@ public class Person {
         this.address = address;
         this.tags.addAll(tags);
         this.studentId = null;
-        this.moduleCode = null;
     }
 
     public Name getName() {
@@ -76,8 +77,12 @@ public class Person {
         return studentId;
     }
 
-    public ModuleCode getModuleCode() {
-        return moduleCode;
+    /**
+     * Returns an immutable module code set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<ModuleCode> getModuleCodes() {
+        return Collections.unmodifiableSet(moduleCodes);
     }
 
     /**
@@ -123,13 +128,13 @@ public class Person {
                 && address.equals(otherPerson.address)
                 && tags.equals(otherPerson.tags)
                 && Objects.equals(studentId, otherPerson.studentId)
-                && Objects.equals(moduleCode, otherPerson.moduleCode);
+                && moduleCodes.equals(otherPerson.moduleCodes);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags, studentId, moduleCode);
+        return Objects.hash(name, phone, email, address, tags, studentId, moduleCodes);
     }
 
     @Override
@@ -141,7 +146,7 @@ public class Person {
                 .add("address", address)
                 .add("tags", tags)
                 .add("studentId", studentId)
-                .add("moduleCode", moduleCode)
+                .add("moduleCodes", moduleCodes)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -23,22 +23,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends"), new StudentId("A1000001X"), new ModuleCode("CS2103T")),
+                getTagSet("friends"), new StudentId("A1000001X"), getModuleCodeSet("CS2103T")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends"), new StudentId("A1000002Y"), new ModuleCode("CS2103T")),
+                getTagSet("colleagues", "friends"), new StudentId("A1000002Y"), getModuleCodeSet("CS2103T", "CS2101")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours"), new StudentId("A1000003Z"), new ModuleCode("CS2040")),
+                getTagSet("neighbours"), new StudentId("A1000003Z"), getModuleCodeSet("CS2040")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family"), new StudentId("A1000004A"), new ModuleCode("CS2106")),
+                getTagSet("family"), new StudentId("A1000004A"), getModuleCodeSet("CS2106", "CS2103T")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates"), new StudentId("A1000005B"), new ModuleCode("CS1010")),
+                getTagSet("classmates"), new StudentId("A1000005B"), getModuleCodeSet("CS1010")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"), new StudentId("A1000006C"), new ModuleCode("CS3244"))
+                getTagSet("colleagues"), new StudentId("A1000006C"), getModuleCodeSet("CS3244"))
         };
     }
 
@@ -59,4 +59,12 @@ public class SampleDataUtil {
                 .collect(Collectors.toSet());
     }
 
+    /**
+     * Returns a module code set containing the list of strings given.
+     */
+    public static Set<ModuleCode> getModuleCodeSet(String... strings) {
+        return Arrays.stream(strings)
+                .map(ModuleCode::new)
+                .collect(Collectors.toSet());
+    }
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -50,7 +50,15 @@ public class PersonCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
         studentId.setText(person.getStudentId() != null ? person.getStudentId().value : "N/A");
-        moduleCode.setText(person.getModuleCode() != null ? person.getModuleCode().value : "N/A");
+        if (!person.getModuleCodes().isEmpty()) {
+            String moduleCodesText = person.getModuleCodes().stream()
+                    .map(mc -> mc.value)
+                    .reduce((a, b) -> a + ", " + b)
+                    .orElse("N/A");
+            moduleCode.setText(moduleCodesText);
+        } else {
+            moduleCode.setText("N/A");
+        }
         email.setText(person.getEmail().value);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -6,13 +6,13 @@
     "address": "123, Jurong West Ave 6, #08-111",
     "tags": [ "friends" ],
     "studentId": "A0123456X",
-    "moduleCode": "CS2103T"
+    "moduleCodes": [ "CS2103T" ]
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "pauline@example.com",
     "address": "4th street",
     "studentId": "A0234567Y",
-    "moduleCode": "CS2040"
+    "moduleCodes": [ "CS2040" ]
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -5,6 +5,6 @@
     "email": "invalid@email!3e",
     "address": "4th street",
     "studentId": "A1234567W",
-    "moduleCode": "CS2103T"
+    "moduleCodes": [ "CS2103T" ]
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -7,7 +7,7 @@
     "address" : "123, Jurong West Ave 6, #08-111",
     "tags" : [ "friends" ],
     "studentId" : "A0123456X",
-    "moduleCode" : "CS2103T"
+    "moduleCodes" : [ "CS2103T" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
@@ -15,7 +15,7 @@
     "address" : "311, Clementi Ave 2, #02-25",
     "tags" : [ "owesMoney", "friends" ],
     "studentId" : "A0234567Y",
-    "moduleCode" : "CS2103T"
+    "moduleCodes" : [ "CS2103T" ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
@@ -23,7 +23,7 @@
     "address" : "wall street",
     "tags" : [ ],
     "studentId" : "A0345678Z",
-    "moduleCode" : "CS2040"
+    "moduleCodes" : [ "CS2040" ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
@@ -31,7 +31,7 @@
     "address" : "10th street",
     "tags" : [ "friends" ],
     "studentId" : "A0456789A",
-    "moduleCode" : "CS3230"
+    "moduleCodes" : [ "CS3230" ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
@@ -39,7 +39,7 @@
     "address" : "michegan ave",
     "tags" : [ ],
     "studentId" : "A0567890B",
-    "moduleCode" : "CS2106"
+    "moduleCodes" : [ "CS2106" ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
@@ -47,7 +47,7 @@
     "address" : "little tokyo",
     "tags" : [ ],
     "studentId" : "A0678901C",
-    "moduleCode" : "CS1010"
+    "moduleCodes" : [ "CS1010" ]
   }, {
     "name" : "George Best",
     "phone" : "9482442",
@@ -55,6 +55,6 @@
     "address" : "4th street",
     "tags" : [ ],
     "studentId" : "A0789012D",
-    "moduleCode" : "CS3244"
+    "moduleCodes" : [ "CS3244" ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -65,8 +65,8 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getPhone().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", address="
                 + editPersonDescriptor.getAddress().orElse(null) + ", student Id="
-                + editPersonDescriptor.getStudentId().orElse(null) + ", module code="
-                + editPersonDescriptor.getModuleCode().orElse(null) + ", tags="
+                + editPersonDescriptor.getStudentId().orElse(null) + ", module codes="
+                + editPersonDescriptor.getModuleCodes().orElse(null) + ", tags="
                 + editPersonDescriptor.getTags().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -90,8 +90,8 @@ public class ListCommandTest {
         ListCommand listCommand = new ListCommand(validModuleCode);
 
         //expected list command output
-        Predicate<Person> modulePredicate = person -> person.getModuleCode() != null
-                                            && person.getModuleCode().equals(validModuleCode);
+        Predicate<Person> modulePredicate = person -> person.getModuleCodes().stream()
+                .anyMatch(mc -> mc.equals(validModuleCode));
 
         expectedModel.updateFilteredPersonList(modulePredicate);
         String expectedMessage = String.format(ListCommand.MESSAGE_SUCCESS_MODULE, validModuleCode);
@@ -113,8 +113,8 @@ public class ListCommandTest {
         ModuleCode noStudentModuleCode = new ModuleCode("CS9999");
         ListCommand listCommand = new ListCommand(noStudentModuleCode);
 
-        Predicate<Person> modulePredicate = person -> person.getModuleCode() != null
-                && person.getModuleCode().equals(noStudentModuleCode);
+        Predicate<Person> modulePredicate = person -> person.getModuleCodes().stream()
+                .anyMatch(mc -> mc.equals(noStudentModuleCode));
 
         expectedModel.updateFilteredPersonList(modulePredicate);
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -172,7 +172,7 @@ public class EditCommandParserTest {
 
         // moduleCode
         userInput = targetIndex.getOneBased() + MODULE_CODE_DESC_AMY;
-        descriptor = new EditPersonDescriptorBuilder().withModuleCode("CS2103T").build();
+        descriptor = new EditPersonDescriptorBuilder().withModuleCodes("CS2103T").build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/address/model/person/PersonStudentFieldsTest.java
+++ b/src/test/java/seedu/address/model/person/PersonStudentFieldsTest.java
@@ -14,7 +14,7 @@ public class PersonStudentFieldsTest {
     public void constructor_withoutStudentFields_setsNulls() {
         Person person = new PersonBuilder().build();
         assertNull(person.getStudentId());
-        assertNull(person.getModuleCode());
+        assertEquals(0, person.getModuleCodes().size());
     }
 
     @Test
@@ -23,11 +23,12 @@ public class PersonStudentFieldsTest {
         String mod = "CS2103T";
         Person person = new PersonBuilder()
                 .withStudentId(sid)
-                .withModuleCode(mod)
+                .withModuleCodes(mod)
                 .build();
 
         assertEquals(new StudentId(sid), person.getStudentId());
-        assertEquals(new ModuleCode(mod), person.getModuleCode());
+        assertEquals(1, person.getModuleCodes().size());
+        assertEquals(new ModuleCode(mod), person.getModuleCodes().iterator().next());
     }
 }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -94,7 +94,7 @@ public class PersonTest {
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags()
-                + ", studentId=" + ALICE.getStudentId() + ", moduleCode=" + ALICE.getModuleCode() + "}";
+                + ", studentId=" + ALICE.getStudentId() + ", moduleCodes=" + ALICE.getModuleCodes() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -25,14 +25,14 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_STUDENT_ID = "B1234567X";
-    private static final String INVALID_MODULE_CODE = "cs2103";
+    private static final List<String> INVALID_MODULE_CODES = List.of("cs2103");
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
     private static final String VALID_STUDENT_ID = "A1234567W";
-    private static final String VALID_MODULE_CODE = "CS2103T";
+    private static final List<String> VALID_MODULE_CODES = List.of("CS2103T");
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -40,7 +40,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                VALID_ADDRESS, VALID_STUDENT_ID, VALID_MODULE_CODE, VALID_TAGS);
+                VALID_ADDRESS, VALID_STUDENT_ID, VALID_MODULE_CODES, VALID_TAGS);
         // Note: BENSON doesn't have studentId and moduleCode, so we can't directly compare with BENSON
         // We'll just ensure it doesn't throw an exception
         person.toModelType();
@@ -50,7 +50,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_STUDENT_ID, VALID_MODULE_CODE, VALID_TAGS);
+                        VALID_STUDENT_ID, VALID_MODULE_CODES, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -58,7 +58,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_STUDENT_ID, VALID_MODULE_CODE, VALID_TAGS);
+                VALID_STUDENT_ID, VALID_MODULE_CODES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -67,7 +67,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_STUDENT_ID, VALID_MODULE_CODE, VALID_TAGS);
+                        VALID_STUDENT_ID, VALID_MODULE_CODES, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -75,7 +75,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_STUDENT_ID, VALID_MODULE_CODE, VALID_TAGS);
+                VALID_STUDENT_ID, VALID_MODULE_CODES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -84,7 +84,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
-                        VALID_STUDENT_ID, VALID_MODULE_CODE, VALID_TAGS);
+                        VALID_STUDENT_ID, VALID_MODULE_CODES, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -92,7 +92,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_STUDENT_ID, VALID_MODULE_CODE, VALID_TAGS);
+                VALID_STUDENT_ID, VALID_MODULE_CODES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -101,7 +101,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                        VALID_STUDENT_ID, VALID_MODULE_CODE, VALID_TAGS);
+                        VALID_STUDENT_ID, VALID_MODULE_CODES, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -109,7 +109,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_STUDENT_ID, VALID_MODULE_CODE, VALID_TAGS);
+                VALID_STUDENT_ID, VALID_MODULE_CODES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -120,7 +120,7 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_STUDENT_ID, VALID_MODULE_CODE, invalidTags);
+                        VALID_STUDENT_ID, VALID_MODULE_CODES, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
@@ -128,7 +128,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidStudentId_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        INVALID_STUDENT_ID, VALID_MODULE_CODE, VALID_TAGS);
+                        INVALID_STUDENT_ID, VALID_MODULE_CODES, VALID_TAGS);
         String expectedMessage = StudentId.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -136,7 +136,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullStudentId_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                null, VALID_MODULE_CODE, VALID_TAGS);
+                null, VALID_MODULE_CODES, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, StudentId.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -145,7 +145,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidModuleCode_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_STUDENT_ID, INVALID_MODULE_CODE, VALID_TAGS);
+                        VALID_STUDENT_ID, INVALID_MODULE_CODES, VALID_TAGS);
         String expectedMessage = ModuleCode.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.model.module.ModuleCode;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -13,6 +12,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.StudentId;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.util.SampleDataUtil;
 
 /**
  * A utility class to help with building EditPersonDescriptor objects.
@@ -41,8 +41,8 @@ public class EditPersonDescriptorBuilder {
         if (person.getStudentId() != null) {
             descriptor.setStudentId(person.getStudentId());
         }
-        if (person.getModuleCode() != null) {
-            descriptor.setModuleCode(person.getModuleCode());
+        if (!person.getModuleCodes().isEmpty()) {
+            descriptor.setModuleCodes(person.getModuleCodes());
         }
         descriptor.setTags(person.getTags());
     }
@@ -88,10 +88,10 @@ public class EditPersonDescriptorBuilder {
     }
 
     /**
-     * Sets the {@code ModuleCode} of the {@code EditPersonDescriptor} that we are building.
+     * Sets the {@code ModuleCodes} of the {@code EditPersonDescriptor} that we are building.
      */
-    public EditPersonDescriptorBuilder withModuleCode(String moduleCode) {
-        descriptor.setModuleCode(new ModuleCode(moduleCode));
+    public EditPersonDescriptorBuilder withModuleCodes(String... moduleCodes) {
+        descriptor.setModuleCodes(SampleDataUtil.getModuleCodeSet(moduleCodes));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -30,7 +30,7 @@ public class PersonBuilder {
     private Address address;
     private Set<Tag> tags;
     private StudentId studentId;
-    private ModuleCode moduleCode;
+    private Set<ModuleCode> moduleCodes;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -42,7 +42,7 @@ public class PersonBuilder {
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
         studentId = null;
-        moduleCode = null;
+        moduleCodes = new HashSet<>();
     }
 
     /**
@@ -55,7 +55,7 @@ public class PersonBuilder {
         address = personToCopy.getAddress();
         tags = new HashSet<>(personToCopy.getTags());
         studentId = personToCopy.getStudentId();
-        moduleCode = personToCopy.getModuleCode();
+        moduleCodes = new HashSet<>(personToCopy.getModuleCodes());
     }
 
     /**
@@ -115,18 +115,28 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code ModuleCode} of the {@code Person} that we are building.
+     * Sets the {@code ModuleCodes} of the {@code Person} that we are building.
      */
-    public PersonBuilder withModuleCode(String moduleCode) {
-        this.moduleCode = new ModuleCode(moduleCode);
+    public PersonBuilder withModuleCodes(String... moduleCodes) {
+        this.moduleCodes = SampleDataUtil.getModuleCodeSet(moduleCodes);
         return this;
     }
 
     /**
-     * Sets the {@code ModuleCode} of the {@code Person} that we are building to null.
+     * Sets the {@code ModuleCode} of the {@code Person} that we are building.
+     * For backward compatibility with single module code tests.
+     */
+    public PersonBuilder withModuleCode(String moduleCode) {
+        this.moduleCodes = SampleDataUtil.getModuleCodeSet(moduleCode);
+        return this;
+    }
+
+    /**
+     * Sets the {@code ModuleCodes} of the {@code Person} that we are building to empty.
+     * For backward compatibility with tests that set moduleCode to null.
      */
     public PersonBuilder withModuleCode() {
-        this.moduleCode = null;
+        this.moduleCodes = new HashSet<>();
         return this;
     }
 
@@ -135,10 +145,10 @@ public class PersonBuilder {
      * If both student-related fields are unset, the constructor without those fields is used.
      */
     public Person build() {
-        if (studentId == null && moduleCode == null) {
+        if (studentId == null && moduleCodes.isEmpty()) {
             return new Person(name, phone, email, address, tags);
         }
-        return new Person(name, phone, email, address, tags, studentId, moduleCode);
+        return new Person(name, phone, email, address, tags, studentId, moduleCodes);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -39,9 +39,9 @@ public class PersonUtil {
         if (person.getStudentId() != null) {
             sb.append(PREFIX_STUDENT_ID + person.getStudentId().value + " ");
         }
-        if (person.getModuleCode() != null) {
-            sb.append(PREFIX_MODULE_CODE + person.getModuleCode().value + " ");
-        }
+        person.getModuleCodes().forEach(
+            mc -> sb.append(PREFIX_MODULE_CODE + mc.value + " ")
+        );
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
@@ -59,8 +59,8 @@ public class PersonUtil {
         descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
         descriptor.getStudentId().ifPresent(studentId -> sb.append(PREFIX_STUDENT_ID)
                 .append(studentId.value).append(" "));
-        descriptor.getModuleCode().ifPresent(moduleCode -> sb.append(PREFIX_MODULE_CODE)
-                .append(moduleCode.value).append(" "));
+        descriptor.getModuleCodes().ifPresent(moduleCodes -> moduleCodes.forEach(
+                mc -> sb.append(PREFIX_MODULE_CODE).append(mc.value).append(" ")));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {


### PR DESCRIPTION
## Summary
- Modified Person class to use Set<ModuleCode> instead of single ModuleCode to support multiple modules per student
- Updated all related commands (Edit, List), storage, UI, and sample data
- Added parseModuleCodes() method to ParserUtil for future use
- Updated all tests to work with the new Set-based implementation

## Related Issue
Closes #77 

## Changes Made
### Main Code
- Person.java: Changed from single ModuleCode field to Set<ModuleCode>
- EditCommand.java: Updated EditPersonDescriptor to use Set<ModuleCode>
- ListCommand.java: Updated filtering to check if person has module in their set
- JsonAdaptedPerson.java: Changed to use List<String> for JSON serialization
- SampleDataUtil.java: Added getModuleCodeSet() helper method
- ParserUtil.java: Added parseModuleCodes() for parsing multiple module codes
- PersonCard.java: Updated UI to display multiple module codes
- Messages.java: Updated format method to handle Set<ModuleCode>

### Test Files
- Updated PersonBuilder, EditPersonDescriptorBuilder, and PersonUtil
- Updated all affected test files to use getModuleCodes() instead of getModuleCode()
- Maintained backward compatibility with withModuleCode() methods

## Test Plan
- [x] All tests pass (./gradlew test)
- [x] Code compiles without errors
- [x] Checkstyle passes