### PR TITLE
Add Remark field class to support personalized student notes

### DIFF
--- a/src/main/java/seedu/address/model/person/Remark.java
+++ b/src/main/java/seedu/address/model/person/Remark.java
@@ -1,0 +1,65 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Person's remark in the address book.
+ * Guarantees: immutable; is always valid
+ */
+public class Remark {
+
+    public static final String MESSAGE_CONSTRAINTS = "Remarks can take any values, and it should not be blank";
+
+    /*
+     * The first character of the remark must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     * The regex uses DOTALL mode to match multi-line remarks.
+     */
+    public static final String VALIDATION_REGEX = "(?s)[^\\s].*";
+
+    public final String value;
+
+    /**
+     * Constructs an {@code Remark}.
+     *
+     * @param remark A valid remark.
+     */
+    public Remark(String remark) {
+        requireNonNull(remark);
+        checkArgument(isValidRemark(remark), MESSAGE_CONSTRAINTS);
+        value = remark;
+    }
+
+    /**
+     * Returns true if a given string is a valid remark.
+     */
+    public static boolean isValidRemark(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Remark)) {
+            return false;
+        }
+
+        Remark otherRemark = (Remark) other;
+        return value.equals(otherRemark.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/test/java/seedu/address/model/person/RemarkTest.java
+++ b/src/test/java/seedu/address/model/person/RemarkTest.java
@@ -1,0 +1,59 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class RemarkTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Remark(null));
+    }
+
+    @Test
+    public void constructor_invalidRemark_throwsIllegalArgumentException() {
+        String invalidRemark = "";
+        assertThrows(IllegalArgumentException.class, () -> new Remark(invalidRemark));
+    }
+
+    @Test
+    public void isValidRemark() {
+        // null remark
+        assertThrows(NullPointerException.class, () -> Remark.isValidRemark(null));
+
+        // invalid remarks
+        assertFalse(Remark.isValidRemark("")); // empty string
+        assertFalse(Remark.isValidRemark(" ")); // spaces only
+
+        // valid remarks
+        assertTrue(Remark.isValidRemark("Student is doing well"));
+        assertTrue(Remark.isValidRemark("a")); // one character
+        // multi-line
+        assertTrue(Remark.isValidRemark("Needs help with OOP concepts\nStruggling with inheritance"));
+        // long remark
+        assertTrue(Remark.isValidRemark("Very long remark with lots of details about student progress"));
+    }
+
+    @Test
+    public void equals() {
+        Remark remark = new Remark("Valid Remark");
+
+        // same values -> returns true
+        assertTrue(remark.equals(new Remark("Valid Remark")));
+
+        // same object -> returns true
+        assertTrue(remark.equals(remark));
+
+        // null -> returns false
+        assertFalse(remark.equals(null));
+
+        // different types -> returns false
+        assertFalse(remark.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(remark.equals(new Remark("Other Valid Remark")));
+    }
+}


### PR DESCRIPTION
Implements the Remark value object following existing field class patterns. This class supports multi-line text and provides validation to ensure remarks are not blank. This is a foundational component for the upcoming feature that allows TAs to record personalized notes for each student.

- Add Remark.java with validation for non-blank remarks
- Support multi-line text using DOTALL regex mode
- Add comprehensive unit tests in RemarkTest.java
- All existing tests continue to pass

Closes: #102 