### PR TITLE
Enhance Tag and Untag Commands to Include Grades

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -120,12 +120,12 @@ public class TagCommand extends Command {
                 && personToTag.getAddress() == null) {
             // Use student constructor
             return new Person(personToTag.getName(), personToTag.getStudentId(),
-                    personToTag.getEmail(), personToTag.getModuleCodes(), updatedTags);
+                    personToTag.getEmail(), personToTag.getModuleCodes(), updatedTags, personToTag.getGrades());
         } else {
             // Use regular person constructor
             return new Person(personToTag.getName(), personToTag.getPhone(), personToTag.getEmail(),
                     personToTag.getAddress(), updatedTags, personToTag.getStudentId(),
-                    personToTag.getModuleCodes());
+                    personToTag.getModuleCodes(), personToTag.getGrades());
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntagCommand.java
@@ -133,12 +133,12 @@ public class UntagCommand extends Command {
                 && personToUntag.getAddress() == null) {
             // Use student constructor
             return new Person(personToUntag.getName(), personToUntag.getStudentId(),
-                    personToUntag.getEmail(), personToUntag.getModuleCodes(), updatedTags);
+                    personToUntag.getEmail(), personToUntag.getModuleCodes(), updatedTags, personToUntag.getGrades());
         } else {
             // Use regular person constructor
             return new Person(personToUntag.getName(), personToUntag.getPhone(), personToUntag.getEmail(),
                     personToUntag.getAddress(), updatedTags, personToUntag.getStudentId(),
-                    personToUntag.getModuleCodes());
+                    personToUntag.getModuleCodes(), personToUntag.getGrades());
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -46,11 +46,11 @@ public class TagCommandTest {
         if (personToTag.getStudentId() != null && personToTag.getPhone() == null
                 && personToTag.getAddress() == null) {
             expectedPerson = new Person(personToTag.getName(), personToTag.getStudentId(),
-                    personToTag.getEmail(), personToTag.getModuleCodes(), expectedTags);
+                    personToTag.getEmail(), personToTag.getModuleCodes(), expectedTags, personToTag.getGrades());
         } else {
             expectedPerson = new Person(personToTag.getName(), personToTag.getPhone(), personToTag.getEmail(),
                     personToTag.getAddress(), expectedTags, personToTag.getStudentId(),
-                    personToTag.getModuleCodes());
+                    personToTag.getModuleCodes(), personToTag.getGrades());
         }
 
         String expectedMessage = String.format(TagCommand.MESSAGE_TAG_PERSON_SUCCESS,
@@ -79,11 +79,11 @@ public class TagCommandTest {
         if (personToTag.getStudentId() != null && personToTag.getPhone() == null
                 && personToTag.getAddress() == null) {
             expectedPerson = new Person(personToTag.getName(), personToTag.getStudentId(),
-                    personToTag.getEmail(), personToTag.getModuleCodes(), expectedTags);
+                    personToTag.getEmail(), personToTag.getModuleCodes(), expectedTags, personToTag.getGrades());
         } else {
             expectedPerson = new Person(personToTag.getName(), personToTag.getPhone(), personToTag.getEmail(),
                     personToTag.getAddress(), expectedTags, personToTag.getStudentId(),
-                    personToTag.getModuleCodes());
+                    personToTag.getModuleCodes(), personToTag.getGrades());
         }
 
         String expectedMessage = String.format(TagCommand.MESSAGE_TAG_PERSON_SUCCESS,
@@ -128,11 +128,11 @@ public class TagCommandTest {
         if (studentToTag.getStudentId() != null && studentToTag.getPhone() == null
                 && studentToTag.getAddress() == null) {
             expectedPerson = new Person(studentToTag.getName(), studentToTag.getStudentId(),
-                    studentToTag.getEmail(), studentToTag.getModuleCodes(), expectedTags);
+                    studentToTag.getEmail(), studentToTag.getModuleCodes(), expectedTags, studentToTag.getGrades());
         } else {
             expectedPerson = new Person(studentToTag.getName(), studentToTag.getPhone(),
                     studentToTag.getEmail(), studentToTag.getAddress(), expectedTags,
-                    studentToTag.getStudentId(), studentToTag.getModuleCodes());
+                    studentToTag.getStudentId(), studentToTag.getModuleCodes(), studentToTag.getGrades());
         }
 
         String expectedMessage = String.format(TagCommand.MESSAGE_TAG_PERSON_SUCCESS,

--- a/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UntagCommandTest.java
@@ -45,11 +45,12 @@ public class UntagCommandTest {
         if (personToUntag.getStudentId() != null && personToUntag.getPhone() == null
                 && personToUntag.getAddress() == null) {
             personWithTag = new Person(personToUntag.getName(), personToUntag.getStudentId(),
-                    personToUntag.getEmail(), personToUntag.getModuleCodes(), updatedTagsWithNew);
+                    personToUntag.getEmail(), personToUntag.getModuleCodes(), updatedTagsWithNew,
+                    personToUntag.getGrades());
         } else {
             personWithTag = new Person(personToUntag.getName(), personToUntag.getPhone(), personToUntag.getEmail(),
                     personToUntag.getAddress(), updatedTagsWithNew, personToUntag.getStudentId(),
-                    personToUntag.getModuleCodes());
+                    personToUntag.getModuleCodes(), personToUntag.getGrades());
         }
 
         model.setPerson(personToUntag, personWithTag);
@@ -67,11 +68,12 @@ public class UntagCommandTest {
         if (personWithTag.getStudentId() != null && personWithTag.getPhone() == null
                 && personWithTag.getAddress() == null) {
             expectedPerson = new Person(personWithTag.getName(), personWithTag.getStudentId(),
-                    personWithTag.getEmail(), personWithTag.getModuleCodes(), expectedTags);
+                    personWithTag.getEmail(), personWithTag.getModuleCodes(), expectedTags,
+                    personWithTag.getGrades());
         } else {
             expectedPerson = new Person(personWithTag.getName(), personWithTag.getPhone(), personWithTag.getEmail(),
                     personWithTag.getAddress(), expectedTags, personWithTag.getStudentId(),
-                    personWithTag.getModuleCodes());
+                    personWithTag.getModuleCodes(), personWithTag.getGrades());
         }
 
         String expectedMessage = String.format(UntagCommand.MESSAGE_UNTAG_PERSON_SUCCESS,
@@ -129,11 +131,12 @@ public class UntagCommandTest {
         if (studentToUntag.getStudentId() != null && studentToUntag.getPhone() == null
                 && studentToUntag.getAddress() == null) {
             expectedPerson = new Person(studentToUntag.getName(), studentToUntag.getStudentId(),
-                    studentToUntag.getEmail(), studentToUntag.getModuleCodes(), expectedTags);
+                    studentToUntag.getEmail(), studentToUntag.getModuleCodes(), expectedTags,
+                    studentToUntag.getGrades());
         } else {
             expectedPerson = new Person(studentToUntag.getName(), studentToUntag.getPhone(),
                     studentToUntag.getEmail(), studentToUntag.getAddress(), expectedTags,
-                    studentToUntag.getStudentId(), studentToUntag.getModuleCodes());
+                    studentToUntag.getStudentId(), studentToUntag.getModuleCodes(), studentToUntag.getGrades());
         }
 
         String expectedMessage = String.format(UntagCommand.MESSAGE_UNTAG_PERSON_SUCCESS,


### PR DESCRIPTION
Updated the Person constructor calls in TagCommand and UntagCommand to include the grades attribute. Adjusted corresponding test cases in TagCommandTest and UntagCommandTest to ensure proper functionality with the new grades field. This change ensures that grades are retained and managed correctly when tagging and untagging persons.