### PR TITLE
Add UI for student remarks feature

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -58,6 +58,8 @@ public class PersonCard extends UiPart<Region> {
     private HBox weekNumbersRow;
     @FXML
     private HBox attendanceRow;
+    @FXML
+    private Label remark;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -92,6 +94,7 @@ public class PersonCard extends UiPart<Region> {
                     grades.getChildren().add(gradeLabel);
                 });
         consultations.setText(getConsultationsSummary(person));
+        remark.setText(person.getRemark() != null ? person.getRemark().value : "No remarks");
     }
 
     /**

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -78,6 +78,16 @@
       <Label fx:id="consultations" text="\$consultations" styleClass="field-value-compact" wrapText="true" />
     </HBox>
 
+    <!-- REMARK - Compact inline -->
+    <HBox spacing="6" alignment="CENTER_LEFT" styleClass="remark-section-compact">
+      <padding>
+        <Insets top="8" right="10" bottom="8" left="10" />
+      </padding>
+
+      <Label text="📝" styleClass="icon-compact" style="-fx-font-size: 13pt;" />
+      <Label fx:id="remark" text="\$remark" styleClass="field-value-compact" wrapText="true" />
+    </HBox>
+
     <!-- TAGS - Compact inline -->
     <FlowPane fx:id="tags" hgap="6" vgap="6" />
 


### PR DESCRIPTION
Display student remarks in PersonCard with a dedicated section using a 📝 icon. The remark field shows "No remarks" when empty and supports multi-line text with text wrapping enabled.

This completes the remarks feature by making the stored remark data visible to users in the student detail view, allowing TAs to quickly see personalized notes for each student.